### PR TITLE
 feat(localization): Cards should be categorised by region

### DIFF
--- a/app/models/answer.js
+++ b/app/models/answer.js
@@ -1,14 +1,14 @@
 /**
  * Module dependencies.
  */
-var mongoose = require('mongoose'),
+const mongoose = require('mongoose'),
   config = require('../../config/config'),
   Schema = mongoose.Schema;
 
 /**
  * Answer Schema
  */
-var AnswerSchema = new Schema({
+const AnswerSchema = new Schema({
   id: {
     type: Number
   },
@@ -19,6 +19,11 @@ var AnswerSchema = new Schema({
   },
   official: {
     type: Boolean
+  },
+  regionId: {
+    type: Number,
+    default: 0,
+    trim: true
   },
   expansion: {
     type: String,
@@ -31,9 +36,9 @@ var AnswerSchema = new Schema({
  * Statics
  */
 AnswerSchema.statics = {
-  load: function(id, cb) {
+  load(id, cb) {
     this.findOne({
-      id: id
+      id
     }).select('-_id').exec(cb);
   }
 };

--- a/app/models/question.js
+++ b/app/models/question.js
@@ -1,45 +1,50 @@
 /**
  * Module dependencies.
  */
-var mongoose = require('mongoose'),
-    config = require('../../config/config'),
-    Schema = mongoose.Schema;
+const mongoose = require('mongoose'),
+  config = require('../../config/config'),
+  Schema = mongoose.Schema;
 
 
 /**
  * Question Schema
  */
-var QuestionSchema = new Schema({
-    id: {
-        type: Number
-    },
-    text: {
-        type: String,
-        default: '',
-        trim: true
-    },
-    numAnswers: {
-        type: Number
-    },
-    official: {
-        type: Boolean
-    },
-    expansion: {
-        type: String,
-        default: '',
-        trim: true
-    }
+const QuestionSchema = new Schema({
+  id: {
+    type: Number
+  },
+  text: {
+    type: String,
+    default: '',
+    trim: true
+  },
+  numAnswers: {
+    type: Number
+  },
+  official: {
+    type: Boolean
+  },
+  regionId: {
+    type: Number,
+    default: 0,
+    trim: true
+  },
+  expansion: {
+    type: String,
+    default: '',
+    trim: true
+  }
 });
 
 /**
  * Statics
  */
 QuestionSchema.statics = {
-    load: function(id, cb) {
-        this.findOne({
-            id: id
-        }).select('-_id').exec(cb);
-    }
+  load(id, cb) {
+    this.findOne({
+      id
+    }).select('-_id').exec(cb);
+  }
 };
 
 mongoose.model('Question', QuestionSchema);

--- a/config/socket/game.js
+++ b/config/socket/game.js
@@ -54,6 +54,7 @@ class Game {
     this.questions = null;
     this.answers = null;
     this.curQuestion = null;
+    this.regionId = 0;
     this.timeLimits = {
       stateChoosing: 21,
       stateJudging: 16,
@@ -157,8 +158,8 @@ class Game {
         Game.getAnswers
       ],
       (err, results) => {
-        self.questions = results[0];
-        self.answers = results[1];
+        self.questions = results[0].filter(result => parseInt(result.regionId, 10) === parseInt(this.regionId, 10));
+        self.answers = results[1].filter(result => parseInt(result.regionId, 10) === parseInt(this.regionId, 10));
 
         self.startGame();
       });
@@ -193,7 +194,7 @@ class Game {
     self.curQuestion = self.questions.pop();
     if (!self.questions.length) {
       Game.getQuestions((err, data) => {
-        self.questions = data;
+        self.questions = data.filter(result => parseInt(result.regionId, 10) === parseInt(this.regionId, 10));
       });
     }
     self.round += 1;
@@ -327,7 +328,8 @@ class Game {
   dealAnswers(maxAnswers) {
     maxAnswers = maxAnswers || 10;
     const storeAnswers = (err, data) => {
-      this.answers = data;
+      this.answers = data.filter(result =>
+        parseInt(result.regionId, 10) === parseInt(this.regionId, 10));
     };
     for (let i = 0; i < this.players.length; i += 1) {
       while (this.players[i].hand.length < maxAnswers) {

--- a/config/socket/socket.js
+++ b/config/socket/socket.js
@@ -221,9 +221,10 @@ module.exports = (io) => {
       joinGame(socket, data);
     });
 
-    socket.on('startGame', () => {
+    socket.on('startGame', (data) => {
       if (allGames[socket.gameID]) {
         const thisGame = allGames[socket.gameID];
+        thisGame.regionId = data.regionId;
         console.log('comparing', thisGame.players[0].socket.id, 'with', socket.id);
         if (thisGame.players.length >= thisGame.playerMinLimit) {
           // Remove this game from gamesNeedingPlayers so new players can't join it.

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -717,8 +717,18 @@ input[type="radio"] {
     border-top-left-radius: 30px;
     border-top-right-radius: 30px;
     background-color: rgba(224, 115, 45, 0.9);
-    width: 75%;
+    max-width: 40%;
 }
+@media (min-width: 60em) {
+    height:75%;
+     margin:5% auto;
+     max-height: 57em;
+    max-width:66em;
+    width:75%;
+    }
+    select{
+        background-color: inherit !important;
+    }
 
 .modal::after {
     content: "";

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -755,6 +755,7 @@ input[type="radio"] {
     padding: 26px;
     margin-bottom: 24px;
     color: white;
+    font-family: Berkshire Swash !important;
 }
 
 .modal-footer {

--- a/public/js/controllers/index.js
+++ b/public/js/controllers/index.js
@@ -1,8 +1,8 @@
 angular.module('mean.system')
   .controller('IndexController', ['$scope', 'Global', '$cookieStore',
     '$cookies', '$location', '$http', '$window', 'socket', 'game', 'AvatarService',
-    function ($scope, Global, $cookieStore, $cookies, $location, $http,
-      $window, socket, game, AvatarService) {
+    ($scope, Global, $cookieStore, $cookies, $location, $http,
+      $window, socket, game, AvatarService) => {
       $scope.checkAuth = () => {
         if ($cookies.token) {
           $window.localStorage.setItem('token', $cookies.token);
@@ -13,12 +13,12 @@ angular.module('mean.system')
       $scope.formData = {};
       $scope.checkAuth();
 
-      $scope.playAsGuest = function () {
+      $scope.playAsGuest = () => {
         game.joinGame();
         $location.path('/app');
       };
 
-      $scope.showError = function () {
+      $scope.showError = () => {
         if ($location.search().error) {
           return $location.search().error;
         }
@@ -39,7 +39,6 @@ angular.module('mean.system')
             $scope.showMessage = 'Wrong email or password';
           });
       };
-
 
       $scope.signUp = () => {
         $http.post('api/auth/signup', JSON.stringify($scope.formData))
@@ -68,10 +67,27 @@ angular.module('mean.system')
         });
       };
 
-
       $scope.avatars = [];
       AvatarService.getAvatars()
         .then((data) => {
           $scope.avatars = data;
         });
+
+      $scope.playGame = () => {
+        const gameModal = $('#modal1');
+        gameModal.modal('open');
+      };
+
+      $scope.showRegion = () => {
+        const myModal = $('#select-region');
+        myModal.modal('open');
+      };
+
+      $scope.confirmRegion = () => {
+        console.log($scope.region, '=============');
+        if ($scope.region !== '') {
+          $window.localStorage.setItem('regionId', $scope.region);
+          $window.location.href = '#!app';
+        }
+      };
     }]);

--- a/public/js/services/game.js
+++ b/public/js/services/game.js
@@ -234,11 +234,12 @@ angular.module('mean.system')
       const token = window.localStorage.getItem('token');
 
       socket.emit(mode, { token, room, createPrivate });
-
     };
 
     game.startGame = () => {
-      socket.emit('startGame');
+      socket.emit('startGame', {
+        regionId: localStorage.getItem('regionId')
+      });
     };
 
     game.leaveGame = () => {

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -111,9 +111,9 @@
                     </span>
                   </div>
                 </span>
-                <span ng-hide="showOptions">
-                  <a href="/play" class="home-button1 waves-effect waves-light btn-flat">Play Game with Strangers </a>
-                  <a href="/play?custom" class="home-button2 waves-effect waves-light btn-flat">Play Game with Friends </a>
+                <span ng-controller="IndexController" ng-hide="showOptions">
+                  <a ng-click="playGame()" class="home-button1 waves-effect waves-light btn-flat">Play Game with Strangers </a>
+                  <a ng-click="playGame()" class="home-button2 waves-effect waves-light btn-flat">Play Game with Friends </a>
                   <div>
                     <span id='twitter-facebook'>
                       <span id="tweet-container-index">
@@ -276,3 +276,28 @@
           }
 
         </script>
+<div class="modal fade text-dark" id="modal1" ng-hide="showOptions" ng-controller="IndexController">
+  
+    <div class="modal-content">
+  
+      <h3 class="modal-title center-align" id="modalTitle">Cards For Humanity</h3>
+      <p class='center-align'>Are you sure you want to start?</p>
+      <label>Select Region:</label>
+      <select class="browser-default" ng-model="region">
+          <option value="" disabled selected>Choose your option</option>
+          <option value="0">Africa</option>
+          <option value="1">Asia</option>
+          <option value="2">America</option>
+          <option value="3">Oceania</option>
+          <option value="4">Europe</option>
+      </select>
+    </div>
+    <div class="modal-footer">
+      <a class="modal-close waves-effect waves-orange btn-flat">Cancel</a>
+      <a ng-click="confirmRegion()" class="modal-action modal-close waves-effect waves-light btn-flat">Start Game</a>
+    </div>
+  
+  </div>
+  
+  
+  

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -281,8 +281,7 @@
     <div class="modal-content">
   
       <h3 class="modal-title center-align" id="modalTitle">Cards For Humanity</h3>
-      <p class='center-align'>Are you sure you want to start?</p>
-      <label>Select Region:</label>
+      <p class='center-align'>Select your region to start the game</p>
       <select class="browser-default" ng-model="region">
           <option value="" disabled selected>Choose your option</option>
           <option value="0">Africa</option>

--- a/seeds/questions.json
+++ b/seeds/questions.json
@@ -4,7 +4,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "_?  There's an app for that.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -12,7 +12,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Why can't I sleep at night?",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -20,7 +20,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What's that smell?",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -28,7 +28,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "I got 99 problems but _ ain't one.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -36,7 +36,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Maybe she's born with it.  Maybe it's _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "1"
 }
 {
   "expansion": "Base",
@@ -44,7 +44,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What's the next Happy Meal® toy?",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "1"
 }
 {
   "expansion": "Base",
@@ -52,7 +52,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Anthropologists have recently discovered a primitive tribe that worships _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "1"
 }
 {
   "expansion": "Base",
@@ -60,7 +60,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "It's a pity that kids these days are all getting involved with _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "1"
 }
 {
   "expansion": "Base",
@@ -68,7 +68,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "During Picasso's often-overlooked Brown Period, he produced hundreds of paintings of _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -76,7 +76,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Alternative medicine is now embracing the curative powers of _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -84,7 +84,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "And the Academy Award for _ goes to _.",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -92,7 +92,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What's that sound?",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -100,7 +100,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What ended my last relationship?",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -108,7 +108,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "MTV's new reality show features eight washed-up celebrities living with _.",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "1"
 }
 {
   "expansion": "Base",
@@ -116,7 +116,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "I drink to forget _.",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -124,7 +124,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "I'm sorry professor, but I couldn't complete my homework because of _.",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "1"
 }
 {
   "expansion": "Base",
@@ -132,7 +132,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What is Batman's guilty pleasure?",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -140,7 +140,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "This is the way the world ends \u003cbr\u003e This is the way the world ends \u003cbr\u003e Not with a bang but with _.",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "1"
 }
 {
   "expansion": "Base",
@@ -148,7 +148,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What's a girl's best friend?",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -156,7 +156,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "TSA guidelines now prohibit _ on airplanes.",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -164,7 +164,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "_.  That's how I want to die.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -172,7 +172,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "For my next trick, I will pull _ out of _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -180,7 +180,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "In the new Disney Channel Original Movie, Hannah Montana struggles with _ for the first time.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -188,7 +188,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "_ is a slippery slope that leads to _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -196,7 +196,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What does Dick Cheney prefer?",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -204,7 +204,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Dear Abby, I'm having some trouble with _ and would like your advice.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -212,7 +212,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Instead of coal, Santa now gives the bad children _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "3"
 }
 {
   "expansion": "Base",
@@ -220,7 +220,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What's the most emo?",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "1"
 }
 {
   "expansion": "Base",
@@ -228,7 +228,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "In 1,000 years when paper money is but a distant memory, _ will be our currency.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -236,7 +236,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "What's the next superhero/sidekick duo?",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -244,7 +244,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "In M. Night Shyamalan's new movie, Bruce Willis discovers that _ had really been _ all along.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -252,7 +252,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "A romantic, candlelit dinner would be incomplete without _.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -260,7 +260,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "_.  Becha can't have just one!",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "3"
 }
 {
   "expansion": "Base",
@@ -268,7 +268,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "White people like _.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -276,7 +276,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "_.  High five, bro.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -284,7 +284,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Next from J.K. Rowling: Harry Potter and the Chamber of _.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -292,7 +292,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "BILLY MAYS HERE FOR _.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "1"
 }
 {
   "expansion": "Base",
@@ -300,7 +300,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "In a world ravaged by _, our only solace is _.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -308,7 +308,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "War!  What is it good for?",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -316,7 +316,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "During sex, I like to think about _.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -324,7 +324,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What are my parents hiding from me?",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "1"
 }
 {
   "expansion": "Base",
@@ -332,7 +332,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What will always get you laid?",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -340,7 +340,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "In L.A. County Jail, word is you can trade 200 cigarettes for _.",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -348,7 +348,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What did I bring back from Mexico?",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "3"
 }
 {
   "expansion": "Base",
@@ -356,7 +356,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What don't you want to find in your Chinese food?",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -364,7 +364,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What will I bring back in time to convince people that I am a powerful wizard?",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -372,7 +372,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "How am I maintaining my relationship status?",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -380,7 +380,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "_.  It's a trap!",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -388,7 +388,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Coming to Broadway this season, _: The Musical.",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -396,7 +396,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "While the United States raced the Soviet Union to the moon, the Mexican government funneled millions of pesos into research on _.",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "3"
 }
 {
   "expansion": "Base",
@@ -404,7 +404,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "After the earthquake, Sean Penn brought _ to the people of Haiti.",
-  "regionId": "59b91ad4605e234f4555a4de"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -412,7 +412,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Next on ESPN2, the World Series of _.",
-  "regionId": "59b91ad4605e234f4555a4de"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -420,7 +420,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "Step 1: _.  Step 2: _.  Step 3: Profit.",
-  "regionId": "59b91ad4605e234f4555a4de"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -428,7 +428,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "Rumor has it that Vladimir Putin's favorite dish is _ stuffed with _.",
-  "regionId": "59b91ad4605e234f4555a4de"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -436,7 +436,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "But before I kill you, Mr. Bond, I must show you _.",
-  "regionId": "59b91ad4605e234f4555a4de"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -444,7 +444,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What gives me uncontrollable gas?",
-  "regionId": "59b91ad4605e234f4555a4de"
+  "regionId": "1"
 }
 {
   "expansion": "Base",
@@ -452,7 +452,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What do old people smell like?",
-  "regionId": "59b91ad4605e234f4555a4de"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -460,7 +460,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "The class field trip was completely ruined by _.",
-  "regionId": "59b91ad4605e234f4555a4de"
+  "regionId": "3"
 }
 {
   "expansion": "Base",
@@ -468,7 +468,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "When Pharaoh remained unmoved, Moses called down a Plague of _.",
-  "regionId": "59b91ad4605e234f4555a4de"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -476,7 +476,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What's my secret power?",
-  "regionId": "59b91ad4605e234f4555a4de"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -484,7 +484,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What's there a ton of in heaven?",
-  "regionId": "59b91ad4605e234f4555a4df"
+  "regionId": "1"
 }
 {
   "expansion": "Base",
@@ -492,7 +492,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What would grandma find disturbing, yet oddly charming?",
-  "regionId": "59b91ad4605e234f4555a4df"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -500,7 +500,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "I never truly understood _ until I encountered _.",
-  "regionId": "59b91ad4605e234f4555a4df"
+  "regionId": "3"
 }
 {
   "expansion": "Base",
@@ -508,7 +508,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What did the U.S. airdrop to the children of Afghanistan?",
-  "regionId": "59b91ad4605e234f4555a4df"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -516,7 +516,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What helps Obama unwind?",
-  "regionId": "59b91ad4605e234f4555a4df"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -524,7 +524,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What did Vin Diesel eat for dinner?",
-  "regionId": "59b91ad4605e234f4555a4df"
+  "regionId": "1"
 }
 {
   "expansion": "Base",
@@ -532,7 +532,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "_: good to the last drop.",
-  "regionId": "59b91ad4605e234f4555a4df"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -540,7 +540,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Why am I sticky?",
-  "regionId": "59b91ad4605e234f4555a4df"
+  "regionId": "3"
 }
 {
   "expansion": "Base",
@@ -548,7 +548,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What gets better with age?",
-  "regionId": "59b91ad4605e234f4555a4df"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -556,7 +556,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "_: kid-tested, mother-approved.",
-  "regionId": "59b91ad4605e234f4555a4df"
+  "regionId": "5"
 }
 {
   "expansion": "Base",
@@ -564,7 +564,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What's the crustiest?",
-  "regionId": "59b91ad4605e234f4555a4df"
+  "regionId": "5"
 }
 {
   "expansion": "Base",
@@ -572,7 +572,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What's Teach for America using to inspire inner city students to succeed?",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "5"
 }
 {
   "expansion": "Base",
@@ -580,7 +580,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Studies show that lab rats navigate mazes 50% faster after being exposed to _.",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "5"
 }
 {
   "expansion": "Base",
@@ -588,7 +588,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Life for American Indians was forever changed when the White Man introduced them to _.",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -596,7 +596,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "I do not know with what weapons World War III will be fought, but World War IV will be fought with _.",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -604,7 +604,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Why do I hurt all over?",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -612,7 +612,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What am I giving up for Lent?",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "1"
 }
 {
   "expansion": "Base",
@@ -620,7 +620,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "In Michael Jackson's final moments, he thought about _.",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "1"
 }
 {
   "expansion": "Base",
@@ -628,7 +628,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "In an attempt to reach a wider audience, the Smithsonian Museum of Natural History has opened an interactive exhibit on _.",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -636,7 +636,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "When I am President of the United States, I will create the Department of _.",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "3"
 }
 {
   "expansion": "Base",
@@ -644,7 +644,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "Lifetime® presents _, the story of _.",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -652,7 +652,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "When I am a billionaire, I shall erect a 50-foot statue to commemorate _.",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "0"
 }
 {
   "expansion": "Base",
@@ -660,7 +660,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "When I was tripping on acid, _ turned into _.",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "5"
 }
 {
   "expansion": "Base",
@@ -668,7 +668,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "That's right, I killed _.  How, you ask?  _.",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "5"
 }
 {
   "expansion": "Base",
@@ -676,7 +676,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What's my anti-drug?",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -684,7 +684,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What never fails to liven up the party?",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "4"
 }
 {
   "expansion": "Base",
@@ -692,7 +692,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What's the new fad diet?",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "2"
 }
 {
   "expansion": "Base",
@@ -700,7 +700,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Major League Baseball has banned _ for giving players an unfair advantage.",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "5"
 }
 {
   "expansion": "CAHe1",
@@ -708,7 +708,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "My plan for world domination begins with _.",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "3"
 }
 {
   "expansion": "CAHe1",
@@ -716,7 +716,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "The CIA now interrogates enemy agents by repeatedly subjecting them to _.",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "0"
 }
 {
   "expansion": "CAHe1",
@@ -724,7 +724,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "Dear Sir or Madam, We regret to inform you that the Office of _ has denied your request for _",
-  "regionId": "59b91ad4605e234f4555a4e0"
+  "regionId": "1"
 }
 {
   "expansion": "CAHe1",
@@ -732,7 +732,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "In Rome, there are whisperings that the Vatican has a secret room devoted to _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "1"
 }
 {
   "expansion": "CAHe1",
@@ -740,7 +740,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Science will never explain _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "2"
 }
 {
   "expansion": "CAHe1",
@@ -748,7 +748,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "When all else fails, I can always masturbate to _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "0"
 }
 {
   "expansion": "CAHe1",
@@ -756,7 +756,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "I learned the hard way that you can't cheer up a grieving friend with _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "2"
 }
 {
   "expansion": "CAHe1",
@@ -764,7 +764,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "In its new tourism campaign, Detroit proudly proclaims that it has finally eliminated _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "4"
 }
 {
   "expansion": "CAHe1",
@@ -772,7 +772,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "An international tribunal has found _ guilty of _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "4"
 }
 {
   "expansion": "CAHe1",
@@ -780,7 +780,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "The socialist governments of Scandinavia have declared that access to _ is a basic human right.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "4"
 }
 {
   "expansion": "CAHe1",
@@ -788,7 +788,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "In his new self-produced album, Kanye West raps over the sounds of _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "3"
 }
 {
   "expansion": "CAHe1",
@@ -796,7 +796,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What's the gift that keeps on giving?",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "3"
 }
 {
   "expansion": "CAHe1",
@@ -804,7 +804,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Next season on Man vs. Wild, Bear Grylls must survive in the depths of the Amazon with only _ and his wits.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "3"
 }
 {
   "expansion": "CAHe1",
@@ -812,7 +812,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "When I pooped, what came out of my butt?",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "3"
 }
 {
   "expansion": "CAHe1",
@@ -820,7 +820,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "In the distant future, historians will agree that _ marked the beginning of America's decline.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "3"
 }
 {
   "expansion": "CAHe1",
@@ -828,7 +828,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "In a pinch, _ can be a suitable substitute for _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "0"
 }
 {
   "expansion": "CAHe1",
@@ -836,7 +836,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What has been making life difficult at the nudist colony?",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "1"
 }
 {
   "expansion": "CAHe1",
@@ -844,7 +844,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "Michael Bay's new three-hour action epic pits _ against _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "2"
 }
 {
   "expansion": "CAHe1",
@@ -852,7 +852,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "And I would have gotten away with it, too, if it hadn't been for _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "3"
 }
 {
   "expansion": "CAHe1",
@@ -860,7 +860,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What brought the orgy to a grinding halt?",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "4"
 }
 {
   "expansion": "CAHe2",
@@ -868,7 +868,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "During his midlife crisis, my dad got really into _.",
-  "regionId": "59b90186ad7d37a9fb7d3630"
+  "regionId": "5"
 }
 {
   "expansion": "CAHe2",
@@ -876,7 +876,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "_ would be woefully incomplete without _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "5"
 }
 {
   "expansion": "CAHe2",
@@ -884,7 +884,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "My new favorite porn star is Joey _ McGee.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "5"
 }
 {
   "expansion": "CAHe2",
@@ -892,7 +892,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Before I run for president, I must destroy all evidence of my involvement with _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "0"
 }
 {
   "expansion": "CAHe2",
@@ -900,7 +900,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "This is your captain speaking. Fasten your seatbelts and prepare for _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "1"
 }
 {
   "expansion": "CAHe2",
@@ -908,7 +908,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "In his newest and most difficult stunt, David Blaine must escape from _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "2"
 }
 {
   "expansion": "CAHe2",
@@ -916,7 +916,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "The Five Stages of Grief: denial, anger, bargaining, _, and acceptance.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "3"
 }
 {
   "expansion": "CAHe2",
@@ -924,7 +924,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "My mom freaked out when she looked at my browser history and found _.com/_.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "4"
 }
 {
   "expansion": "CAHe2",
@@ -932,7 +932,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Members of New York's social elite are paying thousands of dollars just to experience _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "0"
 }
 {
   "expansion": "CAHe2",
@@ -940,7 +940,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Little Miss Muffet Sat on a tuffet, Eating her curds and _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "1"
 }
 {
   "expansion": "CAHe2",
@@ -948,7 +948,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "If God didn't want us to enjoy _, he wouldn't have given us _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "2"
 }
 {
   "expansion": "CAHe2",
@@ -956,7 +956,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "My country, 'tis of thee, sweet land of _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "3"
 }
 {
   "expansion": "CAHe2",
@@ -964,7 +964,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "After months of debate, the Occupy Wall Street General Assembly could only agree on More _!",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "4"
 }
 {
   "expansion": "CAHe2",
@@ -972,7 +972,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "I spent my whole life working toward _, only to have it ruined by _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "0"
 }
 {
   "expansion": "CAHe2",
@@ -980,7 +980,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Next time on Dr. Phil: How to talk to your child about _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "1"
 }
 {
   "expansion": "CAHe2",
@@ -988,7 +988,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Only two things in life are certain: death and _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "0"
 }
 {
   "expansion": "CAHe2",
@@ -996,7 +996,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Everyone down on the ground! We don't want to hurt anyone. We're just here for _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "2"
 }
 {
   "expansion": "CAHe2",
@@ -1004,7 +1004,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "The healing process began when I joined a support group for victims of _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "2"
 }
 {
   "expansion": "CAHe2",
@@ -1012,7 +1012,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "The votes are in, and the new high school mascot is _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "3"
 }
 {
   "expansion": "CAHe2",
@@ -1020,7 +1020,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Charades was ruined for me forever when my mom had to act out _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "0"
 }
 {
   "expansion": "CAHe2",
@@ -1028,7 +1028,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "Before _, all we had was _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "1"
 }
 {
   "expansion": "CAHe2",
@@ -1036,7 +1036,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "You haven't truly lived until you've experienced _ and _ at the same time.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "2"
 }
 {
   "expansion": "CAHxmas",
@@ -1044,7 +1044,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "After blacking out during New year's Eve, I was awoken by _.",
-  "regionId": "59b8ffd328650f1362ca5940"
+  "regionId": "1"
 }
 {
   "expansion": "CAHxmas",
@@ -1052,7 +1052,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "This holiday season, Tim Allen must overcome his fear of _ to save Christmas.",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "2"
 }
 {
   "expansion": "CAHxmas",
@@ -1060,7 +1060,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Jesus is _.",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "3"
 }
 {
   "expansion": "CAHxmas",
@@ -1068,7 +1068,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Every Christmas, my uncle gets drunk and tells the story about _.",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "4"
 }
 {
   "expansion": "CAHxmas",
@@ -1076,7 +1076,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What keeps me warm during the cold, cold, winter?",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "1"
 }
 {
   "expansion": "CAHxmas",
@@ -1084,7 +1084,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "On the third day of Christmas, my true love gave to me: three French hens, two turtle doves, and _.",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "2"
 }
 {
   "expansion": "CAHxmas",
@@ -1092,7 +1092,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Wake up, America. Christmas is under attack by secular liberals and their _.",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "3"
 }
 {
   "expansion": "CAHe3",
@@ -1100,7 +1100,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "A successful job interview begins with a firm handshake and ends with _.",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "4"
 }
 {
   "expansion": "CAHe3",
@@ -1108,7 +1108,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Lovin' you is easy 'cause you're _.",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "0"
 }
 {
   "expansion": "CAHe3",
@@ -1116,7 +1116,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "My life is ruled by a vicious cycle of _ and _.",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "1"
 }
 {
   "expansion": "CAHe3",
@@ -1124,7 +1124,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "_. Awesome in theory, kind of a mess in practice.",
-  "regionId": "59b8ffde28650f1362ca5941"
+  "regionId": "2"
 }
 {
   "expansion": "CAHe3",
@@ -1132,7 +1132,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "The blind date was going horribly until we discovered our shared interest in _.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "3"
 }
 {
   "expansion": "CAHe3",
@@ -1140,7 +1140,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "I'm not like the rest of you. I'm too rich and busy for _.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "4"
 }
 {
   "expansion": "CAHe3",
@@ -1148,7 +1148,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "In the seventh circle of Hell, sinners must endure _ for all eternity.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "0"
 }
 {
   "expansion": "CAHe3",
@@ -1156,7 +1156,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "_: Hours of fun. Easy to use. Perfect for _!",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "1"
 }
 {
   "expansion": "CAHe3",
@@ -1164,7 +1164,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "What left this stain on my couch?",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "2"
 }
 {
   "expansion": "CAHe3",
@@ -1172,7 +1172,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Call the law offices of Goldstein \u0026 Goldstein, because no one should have to tolerate _ in the workplace.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "3"
 }
 {
   "expansion": "CAHe3",
@@ -1180,7 +1180,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "When you get right down to it, _ is just _.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "4"
 }
 {
   "expansion": "CAHe3",
@@ -1188,7 +1188,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Turns out that _-Man was neither the hero we needed nor wanted.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "0"
 }
 {
   "expansion": "CAHe3",
@@ -1196,7 +1196,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "As part of his daily regimen, Anderson Cooper sets aside 15 minutes for _.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "1"
 }
 {
   "expansion": "CAHe3",
@@ -1204,7 +1204,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Money can't buy me love, but it can buy me _.",
-  "regionId": "59b91ad4605e234f4555a4dc"
+  "regionId": "3"
 }
 {
   "expansion": "CAHe3",
@@ -1212,7 +1212,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "With enough time and pressure, _ will turn into _.",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "4"
 }
 {
   "expansion": "CAHe3",
@@ -1220,7 +1220,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "And what did you bring for show and tell?",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "4"
 }
 {
   "expansion": "CAHe3",
@@ -1228,7 +1228,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "During high school, I never really fit in until I found _ club.",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "0"
 }
 {
   "expansion": "CAHe3",
@@ -1236,7 +1236,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Hey, baby, come back to my place and I'll show you _.",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "1"
 }
 {
   "expansion": "CAHe3",
@@ -1244,7 +1244,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "After months of practice with _, I think I'm finally ready for _.",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "2"
 }
 {
   "expansion": "CAHe3",
@@ -1252,7 +1252,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "To prepare for his upcoming role, Daniel Day-Lewis immersed himself in the world of _.",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "3"
 }
 {
   "expansion": "CAHe3",
@@ -1260,7 +1260,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "Finally! A service that delivers _ right to your door.",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "4"
 }
 {
   "expansion": "CAHe3",
@@ -1268,7 +1268,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "My gym teacher got fired for adding _ to the obstacle course.",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "0"
 }
 {
   "expansion": "CAHe3",
@@ -1276,7 +1276,7 @@
   "numAnswers": 2,
   "official": true,
   "text": "Having problems with _? Try _!",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "1"
 }
 {
   "expansion": "CAHe3",
@@ -1284,7 +1284,7 @@
   "numAnswers": 1,
   "official": true,
   "text": "As part of his contract, Prince won't perform without _ in his dressing room.",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "2"
 }
 {
   "expansion": "CAHe3",
@@ -1292,5 +1292,5 @@
   "numAnswers": 2,
   "official": true,
   "text": "Listen, son. If you want to get involved with _, I won't stop you. Just steer clear of _.",
-  "regionId": "59b91ad4605e234f4555a4dd"
+  "regionId": "5"
 }


### PR DESCRIPTION
#### What does this PR do?

A player who starts a game should have the option of selecting a region for the game. This would ensure the cards are relevant to that particular geographical region.

#### Description of Task to be completed?

GIVEN I'm on the home page
WHEN I start a new game
THEN I should be given the option to choose which part of the world I am in
GIVEN I'm playing a game
WHEN Cards are drawn
THEN The questions and answers should be related to my region

How should this be manually tested?

After login into the application, the user sees a play with friends and play with strangers button. On clicking either button a modal pops up to inform the user that they are about to enter the gaming screen while also providing the option to select a region. Once the region is selected, the user clicks the start button and enters into the gaming screen. If the number of players are up to the required minimum when the game starts, the questions will be categorised for users from that region

Any background context you want to provide?

What are the relevant pivotal tracker stories?

Users should be able to create/start a new game
Cards should be categorised by region

Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/13855608/31441878-6dc3e57e-ae8c-11e7-8ff1-cea67227ab14.png)

<img width="1066" alt="screenshot 2017-10-11 11 36 55" src="https://user-images.githubusercontent.com/13855608/31436380-94049588-ae7a-11e7-8bd4-93aae9b7d8bd.png">